### PR TITLE
🔄 Update requirements for Minecraft versions

### DIFF
--- a/contents/docs/getting-started/requirements.mdx
+++ b/contents/docs/getting-started/requirements.mdx
@@ -19,7 +19,7 @@ To join, you need to have the following installed:
 - Bedrock Edition
 - Java Edition
 - Pocket Edition
-- 1.16.2 - 1.20.1
+- 1.16.2 - 1.21.1
 
 <Tabs defaultValue="Java" className="pt-5 pb-1">
   <TabsList className="">


### PR DESCRIPTION
## Summary by Sourcery

Update the documentation to reflect the new supported range of Minecraft versions, now including version 1.21.1.

Documentation:
- Update the supported Minecraft versions in the requirements documentation to include version 1.21.1.