### PR TITLE
📝 Remove outdated Minecraft installation note on requirements page

### DIFF
--- a/contents/docs/getting-started/requirements.mdx
+++ b/contents/docs/getting-started/requirements.mdx
@@ -14,6 +14,7 @@ To join, you need to have the following installed:
 - Java Edition
 - Pocket Edition
 - 1.16.2 - 1.21.1
+- Any cracked client ([TLauncher](https://tlauncher.org/)) is also supported
 
 <Tabs defaultValue="Java" className="pt-5 pb-1">
   <TabsList className="">

--- a/contents/docs/getting-started/requirements.mdx
+++ b/contents/docs/getting-started/requirements.mdx
@@ -8,12 +8,6 @@ To join, you need to have the following installed:
 
 ## Minecraft (ofcourse)
 
-<Note title="Important" type="danger">
-  You need to have the **official Minecraft** installed to get in the server.
-  Tlauncher won't work.
-</Note>
-<br />
-
 ### Supported Versions
 
 - Bedrock Edition


### PR DESCRIPTION
## Summary by Sourcery

Remove outdated note about needing the official Minecraft installation from the requirements page.

Documentation:
- Remove outdated note about the requirement of having the official Minecraft installed from the requirements page.