### PR TITLE
🎨 Add donation link to Ko-Fi in contributing guide

### DIFF
--- a/contents/docs/contribute/contributing.mdx
+++ b/contents/docs/contribute/contributing.mdx
@@ -48,3 +48,8 @@ https://minecraft-mp.com/server/335642/vote/
 1. Join our [Discord](https://discord.gg/ZewyUmtVSS)
 2. Send a message to @ogwarfin or open a ticket
 3. Wait for a response
+
+# Donate to us
+
+## Ko-Fi
+[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/bugattipvp)


### PR DESCRIPTION
## Summary by Sourcery

Add a donation link to Ko-Fi in the contributing guide to encourage financial support from contributors.

Documentation:
- Add a section in the contributing guide with a link to donate via Ko-Fi.