### PR TITLE
✨ Add aria-label to Gallery and Discord icons

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -42,6 +42,7 @@ export function Navbar() {
                   variant: "ghost",
                   size: "icon",
                 })}
+                aria-label="Gallery"
               >
                 <Images className="h-[1.1rem] w-[1.1rem] fill-current" />
               </Link>
@@ -51,6 +52,7 @@ export function Navbar() {
                   variant: "ghost",
                   size: "icon",
                 })}
+                aria-label="Discord"
               >
                 <SiDiscord className="h-[1.1rem] w-[1.1rem]" />
               </Link>


### PR DESCRIPTION
## Summary by Sourcery

Enhance accessibility by adding aria-label attributes to the Gallery and Discord icons in the navbar.

New Features:
- Add aria-label attributes to the Gallery and Discord icons in the navbar for improved accessibility.