### PR TITLE
✨ Add sitemap routes for BugattiPvP website.

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,72 @@
+import type { MetadataRoute } from 'next'
+ 
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: 'https://www.bugattipvp.net',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: 'https://www.bugattipvp.net/docs/getting-started/overview',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+    {
+      url: 'https://www.bugattipvp.net/docs/getting-started/requirements',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+    {
+      url: 'https://www.bugattipvp.net/docs/getting-started/join',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.5,
+    },
+    {
+      url: 'https://www.bugattipvp.net/docs/usage/basic_commands',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.5,
+    },
+    {
+      url: 'https://www.bugattipvp.net/docs/usage/auction_house',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.5,
+    },
+    {
+      url: 'https://www.bugattipvp.net/docs/usage/clans',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.5,
+    },
+    {
+      url: 'https://www.bugattipvp.net/docs/usage/kits',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.5,
+    },
+    {
+      url: 'https://www.bugattipvp.net/docs/usage/pvp',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.5,
+    },
+    {
+      url: 'https://www.bugattipvp.net/docs/origins/introduction',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.5,
+    },
+    {
+      url: 'https://www.bugattipvp.net/docs/contribute/contributing',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.5,
+    },
+  ]
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a sitemap file to the BugattiPvP website, defining routes with their respective URLs, last modified dates, change frequencies, and priorities to enhance SEO and site structure.

New Features:
- Introduce a sitemap for the BugattiPvP website to improve search engine indexing and navigation.