### PR TITLE
✨ Add Premium Kits section to kits documentation

### DIFF
--- a/contents/docs/usage/kits.mdx
+++ b/contents/docs/usage/kits.mdx
@@ -49,25 +49,26 @@ To view the kits, run the command below:
 
 We have also introduced premium kits where you can get better loot for exchanging in-game currency.
 
-<Tabs defaultValue="Diamond" className="pt-5 pb-1">
+<Tabs defaultValue="BoB" className="pt-5 pb-1">
   <TabsList className="">
-    <TabsTrigger value="Diamond">Diamond Kit</TabsTrigger>
+    <TabsTrigger value="BoB">BoB Kit</TabsTrigger>
     <TabsTrigger value="Oreo">Oreo Kit</TabsTrigger>
-    <TabsTrigger value="Premimun Food">Premimun Food</TabsTrigger>
+    <TabsTrigger value="Premium Food">Premium Food</TabsTrigger>
   </TabsList>
-  <TabsContent value="Diamond">
-    The **Diamond Kit** consists of:
+  <TabsContent value="BoB">
+    The **BoB Kit** consists of:
     - 1 Diamond Axe
-    - 1 Stone Pickaxe
-    - 1 Stone Sword
+    - 1 Diamond Pickaxe
+    - 1 Diamond Super Sword
 
     **Cooldown:** 12 Hours<br/>
+    **Requirement:** Level 20+<br/>
     **Price:** $5000
   </TabsContent>
   <TabsContent value="Oreo">
-    The **Oero Kit** consists of:
-    - 1 Iron Hemlate
-    - 1 iron Chestplate
+    The **Oreo Kit** consists of:
+    - 1 Iron Helmet
+    - 1 Iron Chestplate
     - 1 Iron Leggings
     - 1 Iron Boots
     - 1 Iron Sword
@@ -77,17 +78,20 @@ We have also introduced premium kits where you can get better loot for exchangin
     - 1 Iron Hoe
 
     **Cooldown:** 12 Hours<br/>
+    **Requirement:** Level 20+<br/>
     **Price:** $5000
   </TabsContent>
-  <TabsContent value="Premimun Food">
-    The **Premimun Food Kit** consists of:
-    - 1 Golden Carrot
-    - 1 Golden Apple
-    - 1 Bread
-    - 1 Carrot
-    - 1 Cooked Beef
-    - 1 Cooked Chicken
+  <TabsContent value="Premium Food">
+    The **Premium Food Kit** consists of:
+    - 16 Golden Carrots
+    - 32 Golden Apples
+    - 64 Bread
+    - 64 Carrot
+    - 5 Cooked Steak
+    - 5 Cooked Chicken
+
     **Cooldown:** 12 Hours<br/>
+    **Requirement:** Level 20+<br/>
     **Price:** $5000
   </TabsContent>
 </Tabs>

--- a/contents/docs/usage/kits.mdx
+++ b/contents/docs/usage/kits.mdx
@@ -19,6 +19,8 @@ To view the kits, run the command below:
 /kits
 ```
 
+### Free Kits
+
 <Tabs defaultValue="Starter" className="pt-5 pb-1">
   <TabsList className="">
     <TabsTrigger value="Starter">Starter Kit</TabsTrigger>
@@ -40,5 +42,52 @@ To view the kits, run the command below:
     - 5 Cooked Chicken
 
     **Cooldown:** 1 Hour
+  </TabsContent>
+</Tabs>
+
+### Premium Kits
+
+We have also introduced premium kits where you can get better loot for exchanging in-game currency.
+
+<Tabs defaultValue="Diamond" className="pt-5 pb-1">
+  <TabsList className="">
+    <TabsTrigger value="Diamond">Diamond Kit</TabsTrigger>
+    <TabsTrigger value="Oreo">Oreo Kit</TabsTrigger>
+    <TabsTrigger value="Premimun Food">Premimun Food</TabsTrigger>
+  </TabsList>
+  <TabsContent value="Diamond">
+    The **Diamond Kit** consists of:
+    - 1 Diamond Axe
+    - 1 Stone Pickaxe
+    - 1 Stone Sword
+
+    **Cooldown:** 12 Hours<br/>
+    **Price:** $5000
+  </TabsContent>
+  <TabsContent value="Oreo">
+    The **Oero Kit** consists of:
+    - 1 Iron Hemlate
+    - 1 iron Chestplate
+    - 1 Iron Leggings
+    - 1 Iron Boots
+    - 1 Iron Sword
+    - 1 Iron Pickaxe
+    - 1 Iron Axe
+    - 1 Iron Shovel
+    - 1 Iron Hoe
+
+    **Cooldown:** 12 Hours<br/>
+    **Price:** $5000
+  </TabsContent>
+  <TabsContent value="Premimun Food">
+    The **Premimun Food Kit** consists of:
+    - 1 Golden Carrot
+    - 1 Golden Apple
+    - 1 Bread
+    - 1 Carrot
+    - 1 Cooked Beef
+    - 1 Cooked Chicken
+    **Cooldown:** 12 Hours<br/>
+    **Price:** $5000
   </TabsContent>
 </Tabs>


### PR DESCRIPTION
## Summary by Sourcery

Introduce a Premium Kits section in the kits documentation, providing details on the new premium kits available for purchase with in-game currency.

Documentation:
- Add a new section for Premium Kits in the kits documentation, detailing the available premium kits and their contents, cooldowns, and prices.