### PR TITLE
✨ Update: Change cooldown for premium kits to 7 days and 3 days.

### DIFF
--- a/contents/docs/usage/kits.mdx
+++ b/contents/docs/usage/kits.mdx
@@ -61,7 +61,7 @@ We have also introduced premium kits where you can get better loot for exchangin
     - 1 Diamond Pickaxe
     - 1 Diamond Super Sword
 
-    **Cooldown:** 12 Hours<br/>
+    **Cooldown:** 7 Days<br/>
     **Requirement:** Level 20+<br/>
     **Price:** $5000
   </TabsContent>
@@ -77,7 +77,7 @@ We have also introduced premium kits where you can get better loot for exchangin
     - 1 Iron Shovel
     - 1 Iron Hoe
 
-    **Cooldown:** 12 Hours<br/>
+    **Cooldown:** 7 Days<br/>
     **Requirement:** Level 20+<br/>
     **Price:** $5000
   </TabsContent>
@@ -90,7 +90,7 @@ We have also introduced premium kits where you can get better loot for exchangin
     - 5 Cooked Steak
     - 5 Cooked Chicken
 
-    **Cooldown:** 12 Hours<br/>
+    **Cooldown:** 3 Days<br/>
     **Requirement:** Level 20+<br/>
     **Price:** $5000
   </TabsContent>


### PR DESCRIPTION
## Summary by Sourcery

Update the cooldown periods for premium kits in the documentation, changing them from 12 hours to 7 days and 3 days.

Documentation:
- Update the documentation to reflect the new cooldown periods for premium kits, changing from 12 hours to 7 days and 3 days.