### PR TITLE
✨ Update GitHub Actions setup and dependencies 🔄

### DIFF
--- a/.github/workflows/prettier.yaml
+++ b/.github/workflows/prettier.yaml
@@ -1,30 +1,30 @@
 name: Check
-
-# This action works with pull requests and pushes on the main branch
 on:
   pull_request:
+    branches: [main]
   push:
     branches: [main]
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   prettier:
-    name: Prettier Check
-    runs-on: ubuntu-latest
+    name: Prettier
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [18]
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-
-      - name: Run Prettier
-        id: prettier-run
-        uses: rutajdash/prettier-cli-action@v1.0.0
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
         with:
-          config_path: ./.prettierrc.yml
-
-      # This step only runs if prettier finds errors causing the previous step to fail
-      # This steps lists the files where errors were found
-      - name: Prettier Output
-        if: ${{ failure() }}
-        shell: bash
-        run: |
-          echo "The following files are not formatted:"
-          echo "${{steps.prettier-run.outputs.prettier_output}}"
+          version: 8
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install -D
+      - name: Check formatting with Prettier
+        run: pnpm prettier:check

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -16,12 +16,12 @@ export const NAVLINKS = [
   },
   {
     title: "Gallery",
-    href: 'https://gallery.bugattipvp.net/',
+    href: "https://gallery.bugattipvp.net/",
   },
   {
     title: "3D Map",
-    href: 'https://3d.bugattipvp.net/',
-  }
+    href: "https://3d.bugattipvp.net/",
+  },
 ];
 
 export function Navbar() {


### PR DESCRIPTION
- Update Prettier job configuration in GitHub Actions workflow
- Switch to Ubuntu 22.04 for the job environment
- Upgrade Node.js version to 18 in the build process
- Replace deprecated actions/checkout with actions/checkout@v3
- Use pnpm/action-setup@v2 for setting up pnpm
- Add step to install dependencies before checking formatting

## Summary by Sourcery

Update the GitHub Actions workflow for Prettier by switching to Ubuntu 22.04, upgrading Node.js to version 18, and using updated actions for checkout and pnpm setup. Add a step to install dependencies before running Prettier checks and implement concurrency control to manage job execution.

Enhancements:
- Add concurrency control to the GitHub Actions workflow to cancel in-progress jobs for the same group.

CI:
- Update GitHub Actions workflow to use Ubuntu 22.04 for the Prettier job environment.
- Upgrade Node.js version to 18 in the GitHub Actions workflow.
- Replace deprecated actions/checkout@v2 with actions/checkout@v3 in the GitHub Actions workflow.
- Add pnpm/action-setup@v2 to set up pnpm in the GitHub Actions workflow.
- Add a step to install dependencies before checking formatting in the GitHub Actions workflow.